### PR TITLE
Recognise results with drive.google.com prefix

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -32,6 +32,8 @@ chrome.omnibox.onInputEntered.addListener(function (text) {
         chrome.tabs.update({ url: 'https://forms.google.com/create' });
     } else if (/^https:\/\/docs.google.com\//.test(text)) {
         chrome.tabs.update({ url: text });
+    } else if (/^https:\/\/drive.google.com\//.test(text)) {
+        chrome.tabs.update({ url: text });
     } else {
         chrome.tabs.update({ url: 'https://drive.google.com/#search/' + text });
     }


### PR DESCRIPTION
Suggested results for non-Google documents are returned with a drive.google.com prefix, and OmniDrive treats the entire URL as a Drive search if it is selected.  This change will keep the URL, and open the selected file.
