### PR TITLE
Adapt folder URL to link to personal gDrive

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -93,6 +93,10 @@ function onInputChanged(text, suggest) {
             if (xhr.status == 200) {
                 var results = [];
                 xhr.response.items.forEach(function(item) {
+                    folderIdStart = item.alternateLink.indexOf("folderview?id="); // If it's a folder, adapt url
+                    if(folderIdStart!= -1){
+                        item.alternateLink = 'https://drive.google.com/drive/folders/'+item.alternateLink.substring(folderIdStart+14, item.alternateLink.indexOf('&', folderIdStart+14));
+                    }
                     results.push({
                         content: item.alternateLink,
                         description: sanitizeItemTitle(item.title)


### PR DESCRIPTION
Hello François,

I use this chrome extension daily and I would like to access a folder directly, without landing on the folderview first and then clicking on Open in Drive. 
So here's a fix for it. 

Best greetings
M_L
